### PR TITLE
cmd/sips: use a job queue to handle pinning requests

### DIFF
--- a/cmd/sips/pinhandler.go
+++ b/cmd/sips/pinhandler.go
@@ -218,7 +218,7 @@ func (h PinHandler) DeletePin(ctx context.Context, requestID string) error {
 		return BadRequest(log.Errorf("parse request ID %q: %w", requestID, err))
 	}
 
-	tx, err := h.DB.Begin(true)
+	tx, err := h.DB.Begin(false)
 	if err != nil {
 		return log.Errorf("begin transaction: %w", err)
 	}

--- a/cmd/sips/pinhandler.go
+++ b/cmd/sips/pinhandler.go
@@ -50,8 +50,9 @@ func (h PinHandler) Pins(ctx context.Context, query sips.PinQuery) ([]sips.PinSt
 			Status:    pin.Status,
 			Created:   pin.Created,
 			Pin: sips.Pin{
-				CID:  pin.CID,
-				Name: pin.Name,
+				CID:     pin.CID,
+				Name:    pin.Name,
+				Origins: pin.Origins,
 			},
 		})
 	}

--- a/cmd/sips/pinhandler.go
+++ b/cmd/sips/pinhandler.go
@@ -250,7 +250,7 @@ func (h PinHandler) DeletePin(ctx context.Context, requestID string) error {
 	case h.Queue.Delete() <- pin:
 	}
 
-	return tx.Commit()
+	return nil
 }
 
 func auth(ctx context.Context, db storm.Node) (user dbs.User, err error) {

--- a/cmd/sips/pinhandler.go
+++ b/cmd/sips/pinhandler.go
@@ -15,8 +15,9 @@ import (
 )
 
 type PinHandler struct {
-	IPFS *ipfsapi.Client
-	DB   *storm.DB
+	Queue *PinQueue
+	IPFS  *ipfsapi.Client
+	DB    *storm.DB
 }
 
 func (h PinHandler) Pins(ctx context.Context, query sips.PinQuery) ([]sips.PinStatus, error) {
@@ -46,7 +47,7 @@ func (h PinHandler) Pins(ctx context.Context, query sips.PinQuery) ([]sips.PinSt
 	for _, pin := range dbpins {
 		pins = append(pins, sips.PinStatus{
 			RequestID: strconv.FormatUint(pin.ID, 16),
-			Status:    sips.Pinned, // TODO: Handle this properly.
+			Status:    pin.Status,
 			Created:   pin.Created,
 			Pin: sips.Pin{
 				CID:  pin.CID,
@@ -73,23 +74,20 @@ func (h PinHandler) AddPin(ctx context.Context, pin sips.Pin) (sips.PinStatus, e
 	dbpin := dbs.Pin{
 		Created: time.Now(),
 		User:    user.ID,
+		Status:  sips.Queued,
 		Name:    pin.Name,
 		CID:     pin.CID,
+		Origins: pin.Origins,
 	}
 	err = tx.Save(&dbpin)
 	if err != nil {
 		return sips.PinStatus{}, log.Errorf("save pin %q: %w", pin.CID, err)
 	}
 
-	if len(pin.Origins) != 0 {
-		for _, origin := range pin.Origins {
-			go h.IPFS.SwarmConnect(ctx, origin)
-		}
-	}
-
-	_, err = h.IPFS.PinAdd(ctx, pin.CID)
-	if err != nil {
-		return sips.PinStatus{}, log.Errorf("add pin %v: %w", pin.CID, err)
+	select {
+	case <-ctx.Done():
+		return sips.PinStatus{}, log.Errorf("queue add %v: %w", pin.CID, err)
+	case h.Queue.Add() <- dbpin:
 	}
 
 	id, err := h.IPFS.ID(ctx)
@@ -100,7 +98,7 @@ func (h PinHandler) AddPin(ctx context.Context, pin sips.Pin) (sips.PinStatus, e
 
 	return sips.PinStatus{
 		RequestID: strconv.FormatUint(dbpin.ID, 16),
-		Status:    sips.Pinning,
+		Status:    dbpin.Status,
 		Created:   dbpin.Created,
 		Delegates: id.Addresses,
 		Pin:       pin,
@@ -175,28 +173,25 @@ func (h PinHandler) UpdatePin(ctx context.Context, requestID string, pin sips.Pi
 		}
 		return sips.PinStatus{}, err
 	}
-	oldCID := dbpin.CID
 
 	if dbpin.User != user.ID {
 		return sips.PinStatus{}, NotFound(log.Errorf("find pin %v: %w", requestID, storm.ErrNotFound))
 	}
 
+	oldpin := dbpin
+	dbpin.Status = sips.Queued
 	dbpin.Name = pin.Name
 	dbpin.CID = pin.CID
+	dbpin.Origins = pin.Origins
 	err = tx.Update(&dbpin)
 	if err != nil {
 		return sips.PinStatus{}, log.Errorf("update pin %v: %w", requestID, err)
 	}
 
-	if len(pin.Origins) != 0 {
-		for _, origin := range pin.Origins {
-			go h.IPFS.SwarmConnect(ctx, origin)
-		}
-	}
-
-	_, err = h.IPFS.PinUpdate(ctx, oldCID, pin.CID, false)
-	if err != nil {
-		return sips.PinStatus{}, log.Errorf("add pin %v: %w", pin.CID, err)
+	select {
+	case <-ctx.Done():
+		return sips.PinStatus{}, log.Errorf("queue update %v: %w", requestID, ctx.Err())
+	case h.Queue.Update() <- [2]dbs.Pin{oldpin, dbpin}:
 	}
 
 	id, err := h.IPFS.ID(ctx)
@@ -207,7 +202,7 @@ func (h PinHandler) UpdatePin(ctx context.Context, requestID string, pin sips.Pi
 
 	return sips.PinStatus{
 		RequestID: requestID,
-		Status:    sips.Pinning,
+		Status:    dbpin.Status,
 		Created:   dbpin.Created,
 		Delegates: id.Addresses,
 		Pin: sips.Pin{
@@ -248,14 +243,10 @@ func (h PinHandler) DeletePin(ctx context.Context, requestID string) error {
 		return NotFound(log.Errorf("find pin %v: %w", requestID, storm.ErrNotFound))
 	}
 
-	err = tx.DeleteStruct(&pin)
-	if err != nil {
-		return log.Errorf("delete pin %v: %w", requestID, err)
-	}
-
-	_, err = h.IPFS.PinRm(ctx, pin.CID)
-	if err != nil {
-		return log.Errorf("unpin %v: %w", pin.CID, err)
+	select {
+	case <-ctx.Done():
+		return log.Errorf("queue delete %v: %w", requestID, ctx.Err())
+	case h.Queue.Delete() <- pin:
 	}
 
 	return tx.Commit()

--- a/cmd/sips/pinqueue.go
+++ b/cmd/sips/pinqueue.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"sync/atomic"
 
 	"github.com/DeedleFake/sips"
@@ -90,6 +91,11 @@ func (q *PinQueue) queueExisting(ctx context.Context) {
 	var pins []dbs.Pin
 	err = tx.Select(sq.In("Status", []sips.RequestStatus{sips.Queued, sips.Pinning})).Find(&pins)
 	if err != nil {
+		if errors.Is(err, storm.ErrNotFound) {
+			log.Infof("No existing queued or in-progress pins.")
+			return
+		}
+
 		log.Errorf("find existing queued pins: %w", err)
 		return
 	}

--- a/cmd/sips/pinqueue.go
+++ b/cmd/sips/pinqueue.go
@@ -205,7 +205,9 @@ func (q *PinQueue) addPin(ctx context.Context, done chan<- uint64, pin dbs.Pin) 
 			return
 		case progress, closed := <-progress:
 			if closed {
-				break
+				log.Infof("Finished pinning %v as %q (%v)", pin.CID, pin.Name, pin.ID)
+				pin.Status = sips.Pinned
+				return
 			}
 
 			if progress.Err != nil {
@@ -215,8 +217,6 @@ func (q *PinQueue) addPin(ctx context.Context, done chan<- uint64, pin dbs.Pin) 
 			}
 		}
 	}
-
-	pin.Status = sips.Pinned
 }
 
 func (q *PinQueue) updatePin(ctx context.Context, done chan<- uint64, from, to dbs.Pin) {

--- a/cmd/sips/pinqueue.go
+++ b/cmd/sips/pinqueue.go
@@ -252,6 +252,7 @@ func (q *PinQueue) updatePin(ctx context.Context, done chan<- uint64, from, to d
 		to.Status = sips.Failed
 		return
 	}
+	log.Infof("Pin %v updated from %v to %v.", to.ID, from.CID, to.CID)
 
 	to.Status = sips.Pinned
 }
@@ -266,6 +267,7 @@ func (q *PinQueue) deletePin(ctx context.Context, done chan<- uint64, pin dbs.Pi
 		log.Errorf("remove pin %v from IPFS: %w", pin.CID, err)
 		return
 	}
+	log.Infof("Pin %v (%v, %v) deleted.", pin.ID, pin.Name, pin.CID)
 
 	err = q.DB.DeleteStruct(&pin)
 	if err != nil {

--- a/cmd/sips/pinqueue.go
+++ b/cmd/sips/pinqueue.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"context"
+	"sync/atomic"
+
+	"github.com/DeedleFake/sips/dbs"
+	"github.com/DeedleFake/sips/internal/ipfsapi"
+	"github.com/asdine/storm"
+)
+
+type PinQueue struct {
+	running uint32
+	stop    chan struct{}
+	done    chan struct{}
+
+	add    chan dbs.Pin
+	update chan [2]dbs.Pin
+	del    chan dbs.Pin
+
+	IPFS *ipfsapi.Client
+	DB   *storm.DB
+}
+
+func (q *PinQueue) setRunning() bool {
+	return atomic.CompareAndSwapUint32(&q.running, 0, 1)
+}
+
+func (q *PinQueue) unsetRunning() {
+	atomic.StoreUint32(&q.running, 0)
+}
+
+func (q *PinQueue) checkRunning() {
+	select {
+	case <-q.stop:
+		panic("not running")
+	default:
+		if atomic.LoadUint32(&q.running) == 0 {
+			panic("not running")
+		}
+	}
+}
+
+func (q *PinQueue) Start(ctx context.Context) {
+	if !q.setRunning() {
+		panic("already running")
+	}
+
+	go func() {
+		q.stop = make(chan struct{})
+		q.done = make(chan struct{})
+
+		q.add = make(chan dbs.Pin)
+		q.update = make(chan [2]dbs.Pin)
+		q.del = make(chan dbs.Pin)
+
+		q.run(ctx)
+	}()
+}
+
+func (q *PinQueue) Stop() {
+	close(q.stop)
+	<-q.done
+}
+
+func (q *PinQueue) Add() chan<- dbs.Pin {
+	q.checkRunning()
+	return q.add
+}
+
+func (q *PinQueue) Update() chan<- [2]dbs.Pin {
+	q.checkRunning()
+	return q.update
+}
+
+func (q *PinQueue) Delete() chan<- dbs.Pin {
+	q.checkRunning()
+	return q.del
+}
+
+func (q *PinQueue) run(ctx context.Context) {
+	defer close(q.done)
+	defer q.unsetRunning()
+
+	add := q.add
+	update := q.update
+	del := q.del
+
+	var stopping bool
+	jobs := make(map[uint64]context.CancelFunc)
+	jobctx, cancelAll := context.WithCancel(ctx)
+	jobdone := make(chan uint64)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+
+		case <-q.stop:
+			cancelAll()
+			add = nil
+			update = nil
+			del = nil
+			stopping = true
+
+		case id := <-jobdone:
+			delete(jobs, id)
+			if stopping && (len(jobs) == 0) {
+				return
+			}
+
+		case pin := <-add:
+			sub, cancel := context.WithCancel(jobctx)
+			jobs[pin.ID] = cancel
+			go q.addPin(sub, jobdone, pin)
+
+		case pins := <-update:
+			sub, cancel := context.WithCancel(jobctx)
+			jobs[pins[1].ID] = cancel
+			go q.updatePin(sub, jobdone, pins[0], pins[1])
+
+		case pin := <-del:
+			sub, cancel := context.WithCancel(jobctx)
+			jobs[pin.ID] = cancel
+			go q.deletePin(sub, jobdone, pin)
+		}
+	}
+}
+
+func (q *PinQueue) addPin(ctx context.Context, done chan<- uint64, pin dbs.Pin) {
+	defer func() {
+		done <- pin.ID
+	}()
+
+	panic("Not implemented.")
+}
+
+func (q *PinQueue) updatePin(ctx context.Context, done chan<- uint64, from, to dbs.Pin) {
+	defer func() {
+		// from and to should always have the same ID, so the choice here
+		// is arbitrary.
+		done <- to.ID
+	}()
+
+	panic("Not implemented.")
+}
+
+func (q *PinQueue) deletePin(ctx context.Context, done chan<- uint64, pin dbs.Pin) {
+	defer func() {
+		done <- pin.ID
+	}()
+
+	panic("Not implemented.")
+}

--- a/cmd/sips/pinqueue.go
+++ b/cmd/sips/pinqueue.go
@@ -89,7 +89,7 @@ func (q *PinQueue) queueExisting(ctx context.Context) {
 	defer tx.Rollback()
 
 	var pins []dbs.Pin
-	err = tx.Select(sq.In("Status", []sips.RequestStatus{"", sips.Queued, sips.Pinning})).Find(&pins)
+	err = tx.Select(sq.In("Status", []sips.RequestStatus{sips.Queued, sips.Pinning})).Find(&pins)
 	if err != nil {
 		if errors.Is(err, storm.ErrNotFound) {
 			log.Infof("No existing queued or in-progress pins.")

--- a/cmd/sips/pinqueue.go
+++ b/cmd/sips/pinqueue.go
@@ -205,7 +205,7 @@ func (q *PinQueue) addPin(ctx context.Context, done chan<- uint64, pin dbs.Pin) 
 			return
 		case progress, closed := <-progress:
 			if closed {
-				log.Infof("Finished pinning %v as %q (%v)", pin.CID, pin.Name, pin.ID)
+				log.Infof("Pinned %v as %q (%v)", pin.CID, pin.Name, pin.ID)
 				pin.Status = sips.Pinned
 				return
 			}
@@ -267,7 +267,7 @@ func (q *PinQueue) deletePin(ctx context.Context, done chan<- uint64, pin dbs.Pi
 		log.Errorf("remove pin %v from IPFS: %w", pin.CID, err)
 		return
 	}
-	log.Infof("Pin %v (%v, %v) deleted.", pin.ID, pin.Name, pin.CID)
+	log.Infof("Pin %v (%q, %v) deleted.", pin.ID, pin.Name, pin.CID)
 
 	err = q.DB.DeleteStruct(&pin)
 	if err != nil {

--- a/cmd/sips/pinqueue.go
+++ b/cmd/sips/pinqueue.go
@@ -195,6 +195,13 @@ func (q *PinQueue) addPin(ctx context.Context, done chan<- uint64, pin dbs.Pin) 
 
 			if progress.Err != nil {
 				log.Errorf("pin %v to IPFS: %w", pin.CID, progress.Err)
+
+				pin.Status = sips.Failed
+				err = q.DB.Update(&pin)
+				if err != nil {
+					log.Errorf("update pin %v status to failed: %w", pin.ID, err)
+					return
+				}
 				return
 			}
 		}

--- a/cmd/sips/sips.go
+++ b/cmd/sips/sips.go
@@ -55,6 +55,7 @@ func run(ctx context.Context) error {
 	log.Infof("Database opened at %q", dbpath)
 
 	if *domigration {
+		log.Infof("Running migrations...")
 		err = migrate.Run(db)
 		if err != nil {
 			return fmt.Errorf("migrate database: %w", err)

--- a/cmd/sips/sips.go
+++ b/cmd/sips/sips.go
@@ -52,9 +52,17 @@ func run(ctx context.Context) error {
 	defer db.Close()
 	log.Infof("Database opened at %q", dbpath)
 
-	ph := PinHandler{
+	queue := PinQueue{
 		IPFS: ipfs,
 		DB:   db,
+	}
+	queue.Start(ctx)
+	defer queue.Stop()
+
+	ph := PinHandler{
+		Queue: &queue,
+		IPFS:  ipfs,
+		DB:    db,
 	}
 
 	server := http.Server{

--- a/cmd/sipsctl/cmd/pins.go
+++ b/cmd/sipsctl/cmd/pins.go
@@ -85,7 +85,7 @@ func init() {
 			}
 
 			for _, pin := range pins {
-				fmt.Printf("%v: %v as %q\n", pin.ID, pin.CID, pin.Name)
+				fmt.Printf("%v: %v as %q (%v)\n", pin.ID, pin.CID, pin.Name, pin.Status)
 			}
 
 			return nil

--- a/dbs/migrate/2021-06-22T15:10:17_AddPinStatus.go
+++ b/dbs/migrate/2021-06-22T15:10:17_AddPinStatus.go
@@ -1,0 +1,39 @@
+package migrate
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/DeedleFake/sips"
+	"github.com/DeedleFake/sips/dbs"
+	"github.com/asdine/storm"
+)
+
+func init() {
+	v, err := time.Parse(VersionLayout, "2021-06-22T15:10:17")
+	if err != nil {
+		panic(fmt.Errorf("parse generated migration version %q: %w", "2021-06-22T15:10:17", err))
+	}
+
+	register(v, func(db storm.Node) error {
+		var pins []dbs.Pin
+		err := db.All(&pins)
+		if err != nil {
+			return fmt.Errorf("get pins: %w", err)
+		}
+
+		for _, pin := range pins {
+			if pin.Status != "" {
+				continue
+			}
+
+			pin.Status = sips.Queued
+			err = db.Update(&pin)
+			if err != nil {
+				return fmt.Errorf("update pin %v: %w", pin.ID, err)
+			}
+		}
+
+		return nil
+	})
+}

--- a/dbs/schema.go
+++ b/dbs/schema.go
@@ -2,6 +2,8 @@ package dbs
 
 import (
 	"time"
+
+	"github.com/DeedleFake/sips"
 )
 
 // User reprsents a user in the database.
@@ -22,7 +24,9 @@ type Token struct {
 type Pin struct {
 	ID      uint64 `storm:"increment"`
 	Created time.Time
-	User    uint64 `storm:"index"`
-	Name    string `storm:"index"`
-	CID     string `storm:"index"`
+	User    uint64             `storm:"index"`
+	Status  sips.RequestStatus `storm:"index"`
+	Name    string             `storm:"index"`
+	CID     string             `storm:"index"`
+	Origins []string
 }

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	go.etcd.io/bbolt v1.3.6 // indirect
 	golang.org/x/net v0.0.0-20210226172049-e18ecbb05110 // indirect
-	golang.org/x/sys v0.0.0-20210603125802-9665404d3644 // indirect
+	golang.org/x/sys v0.0.0-20210611083646-a4fc73990273
 	google.golang.org/appengine v1.6.7 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -252,8 +252,8 @@ golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200923182605-d9f96fdee20d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210603125802-9665404d3644 h1:CA1DEQ4NdKphKeL70tvsWNdT5oFh1lOjihRcEDROi0I=
-golang.org/x/sys v0.0.0-20210603125802-9665404d3644/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210611083646-a4fc73990273 h1:faDu4veV+8pcThn4fewv6TVlNCezafGoC1gM/mxQLbQ=
+golang.org/x/sys v0.0.0-20210611083646-a4fc73990273/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/handler.go
+++ b/handler.go
@@ -65,6 +65,10 @@ func tokenFromRequest(req *http.Request) (string, bool) {
 type PinHandler interface {
 	// Pins returns a list of pinning request statuses based on the
 	// given query.
+	//
+	// BUG: Doesn't properly allow a differenation between number of
+	// results returned and total number of results, thus breaking
+	// paging.
 	Pins(ctx context.Context, query PinQuery) ([]PinStatus, error)
 
 	// AddPin adds a new pin to the service's backend.

--- a/pin.go
+++ b/pin.go
@@ -18,7 +18,7 @@ type PinStatus struct {
 	RequestID string        `json:"requestid"`
 	Status    RequestStatus `json:"status"`
 	Created   time.Time     `json:"created"`
-	Delegates []string      `json:"delegates"`
+	Delegates []string      `json:"delegates,omitempty"`
 	Info      interface{}   `json:"info,omitempty"`
 
 	Pin Pin `json:"pin"`
@@ -28,6 +28,6 @@ type PinStatus struct {
 type Pin struct {
 	CID     string      `json:"cid"`
 	Name    string      `json:"name"`
-	Origins []string    `json:"origins"`
+	Origins []string    `json:"origins,omitempty"`
 	Meta    interface{} `json:"meta,omitempty"`
 }


### PR DESCRIPTION
Closes #10. Blocked on #12.

This adds a job queue that handles interactions with the IPFS node for the purpose of adding, updating, and removing pins. Without a job queue, the pinning is dependent on the timeout of the client that has hit the correct SIPS endpoint, meaning that a lost connection from the client will result in a pin request failing.