### PR TITLE
docker, cmd/sips: update Go to 1.17 and standardize logging format a bit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16-alpine AS build
+FROM golang:1.17-alpine AS build
 
 WORKDIR /build
 COPY . /build

--- a/cmd/sips/pinqueue.go
+++ b/cmd/sips/pinqueue.go
@@ -234,7 +234,7 @@ func (q *PinQueue) addPin(ctx context.Context, pin *ent.Pin) {
 			return
 		case progress, closed := <-progress:
 			if closed {
-				log.Infof("Pinned %v as %q (%v)", pin.CID, pin.Name, pin.ID)
+				log.Infof("pinned %v as %q (%v)", pin.CID, pin.Name, pin.ID)
 				status = sips.Pinned
 				return
 			}
@@ -292,7 +292,7 @@ func (q *PinQueue) updatePin(ctx context.Context, from, to *ent.Pin) {
 		status = sips.Failed
 		return
 	}
-	log.Infof("Pin %v updated from %v to %v.", to.ID, from.CID, to.CID)
+	log.Infof("pin %v updated from %v to %v", to.ID, from.CID, to.CID)
 
 	status = sips.Pinned
 }
@@ -310,7 +310,7 @@ func (q *PinQueue) deletePin(ctx context.Context, pin *ent.Pin) {
 		log.Errorf("remove pin %v from IPFS: %w", pin.CID, err)
 		return
 	}
-	log.Infof("Pin %v (%q, %v) deleted.", pin.ID, pin.Name, pin.CID)
+	log.Infof("pin %v (%q, %v) deleted", pin.ID, pin.Name, pin.CID)
 
 	err = tx.Pin.DeleteOneID(pin.ID).Exec(ctx)
 	if err != nil {

--- a/cmd/sips/sips.go
+++ b/cmd/sips/sips.go
@@ -51,10 +51,10 @@ func run(ctx context.Context) error {
 		return fmt.Errorf("open database: %w", err)
 	}
 	defer entc.Close()
-	log.Infof("Database opened at %q", dbpath)
+	log.Infof("database opened at %q", dbpath)
 
 	if *domigration {
-		log.Infof("Running migrations...")
+		log.Infof("running database migration")
 		err = entc.Schema.Create(ctx)
 		if err != nil {
 			return fmt.Errorf("migrate database: %w", err)
@@ -89,11 +89,11 @@ func run(ctx context.Context) error {
 		sctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 
-		log.Infof("Exiting...")
+		log.Infof("exiting")
 		shutdown <- server.Shutdown(sctx)
 	}()
 
-	log.Infof("Starting server...")
+	log.Infof("starting server on %q", *addr)
 	err = server.ListenAndServe()
 	if err != nil {
 		if !errors.Is(err, http.ErrServerClosed) {

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/lib/pq v1.10.3
 	github.com/spf13/cobra v1.2.1
-	golang.org/x/sys v0.0.0-20211023085530-d6a326fbbf70
+	golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -501,8 +501,8 @@ golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211023085530-d6a326fbbf70 h1:SeSEfdIxyvwGJliREIJhRPPXvW6sDlLT+UQ3B0hD0NA=
-golang.org/x/sys v0.0.0-20211023085530-d6a326fbbf70/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359 h1:2B5p2L5IfGiD7+b9BOoRMC6DgObAVZV+Fsp050NqXik=
+golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
Informational logs now always start with a lowercase letter unless starting with something specific that should be capitalized, and don't just sometimes end with punctuation at random.